### PR TITLE
Add MissionTraffic handle

### DIFF
--- a/Time/TimeHandler.cs
+++ b/Time/TimeHandler.cs
@@ -21,6 +21,8 @@ namespace FusionLibrary
         public static bool IsNight { get; internal set; }
 
         public static bool TrafficVolumeYearBased { get; set; }
+        
+        public static bool MissionTraffic = false;
 
         public static bool RealTime
         {
@@ -89,7 +91,7 @@ namespace FusionLibrary
                 OnDayNightChange?.Invoke();
             }
 
-            if (!TrafficVolumeYearBased)
+            if (!TrafficVolumeYearBased || MissionTraffic)
             {
                 return;
             }


### PR DESCRIPTION
By adding MissionTraffic handle, external scripts can preempt the year-based traffic tick as necessary, and can restore traffic to normal by merely setting it to false and letting the year-based traffic tick do the rest.