### PR TITLE
Update MomentReplica to be more robust

### DIFF
--- a/Replica/MomentReplica.cs
+++ b/Replica/MomentReplica.cs
@@ -23,7 +23,7 @@ namespace FusionLibrary
 
         public bool Applied = false;
 
-        public double MomentDuration { get; set; } = 1;
+        public double MomentDuration { get; set; } = 10;
 
         public MomentReplica(DateTime dateTime)
         {

--- a/Replica/MomentReplica.cs
+++ b/Replica/MomentReplica.cs
@@ -19,7 +19,11 @@ namespace FusionLibrary
         public DateTime CurrentDate { get; set; }
         public List<VehicleReplica> VehicleReplicas { get; set; }
 
-        public bool LockWeather { get; set; }
+        public bool TransitionWeather { get; set; } = false;
+
+        public bool Applied = false;
+
+        public double MomentDuration { get; set; } = 1;
 
         public MomentReplica(DateTime dateTime)
         {
@@ -29,7 +33,24 @@ namespace FusionLibrary
 
         public MomentReplica()
         {
-            Update();
+            CurrentDate = FusionUtils.CurrentTime;
+
+            Weather = World.Weather;
+            RainLevel = FusionUtils.RainLevel;
+            PuddleLevel = RainPuddleEditor.Level;
+
+            WantedLevel = Game.Player.WantedLevel;
+
+            VehicleReplicas = new List<VehicleReplica>();
+
+            TimeHandler.UsedVehiclesByPlayer.ForEach(x =>
+            {
+                if (x != FusionUtils.PlayerVehicle)
+                {
+                    VehicleReplicas.Add(new VehicleReplica(x));
+                }
+            });
+            MomentReplicas.Add(this);
         }
 
         public static MomentReplica SearchForMoment()
@@ -47,7 +68,7 @@ namespace FusionLibrary
 
         public bool IsNow()
         {
-            if (CurrentDate.Between(FusionUtils.CurrentTime.AddMinutes(-10), FusionUtils.CurrentTime.AddMinutes(10)))
+            if (CurrentDate.Between(FusionUtils.CurrentTime.AddMinutes(-MomentDuration), FusionUtils.CurrentTime.AddMinutes(MomentDuration)))
             {
                 return true;
             }
@@ -93,36 +114,26 @@ namespace FusionLibrary
 
         public void Apply()
         {
-            World.Weather = Weather;
-            RainPuddleEditor.Level = PuddleLevel;
-            FusionUtils.RainLevel = RainLevel;
-            Game.Player.WantedLevel = WantedLevel;
-
-            VehicleReplicas?.ForEach(x => TimeHandler.UsedVehiclesByPlayer.Add(x.Spawn(SpawnFlags.Default)));
-        }
-
-        public void Update()
-        {
-            CurrentDate = FusionUtils.CurrentTime;
-
-            if (!LockWeather)
+            if (!Applied)
             {
-                Weather = World.Weather;
-                RainLevel = FusionUtils.RainLevel;
-                PuddleLevel = RainPuddleEditor.Level;
-            }
-
-            WantedLevel = Game.Player.WantedLevel;
-
-            VehicleReplicas = new List<VehicleReplica>();
-
-            TimeHandler.UsedVehiclesByPlayer.ForEach(x =>
-            {
-                if (x != FusionUtils.PlayerVehicle)
+                if (TransitionWeather)
                 {
-                    VehicleReplicas.Add(new VehicleReplica(x));
+                    World.TransitionToWeather(Weather, 2);
+                    RainPuddleEditor.Level = PuddleLevel;
+                    FusionUtils.RainLevel = RainLevel;
                 }
-            });
+                else
+                {
+                    World.Weather = Weather;
+                    RainPuddleEditor.Level = PuddleLevel;
+                    FusionUtils.RainLevel = RainLevel;
+                }
+
+                Game.Player.WantedLevel = WantedLevel;
+
+                VehicleReplicas?.ForEach(x => TimeHandler.UsedVehiclesByPlayer.Add(x.Spawn(SpawnFlags.Default)));
+                Applied = true;
+            }
         }
     }
 }

--- a/Replica/MomentReplica.cs
+++ b/Replica/MomentReplica.cs
@@ -19,11 +19,7 @@ namespace FusionLibrary
         public DateTime CurrentDate { get; set; }
         public List<VehicleReplica> VehicleReplicas { get; set; }
 
-        public bool TransitionWeather { get; set; } = false;
-
-        public bool Applied = false;
-
-        public double MomentDuration { get; set; } = 1;
+        public bool LockWeather { get; set; }
 
         public MomentReplica(DateTime dateTime)
         {
@@ -33,24 +29,7 @@ namespace FusionLibrary
 
         public MomentReplica()
         {
-            CurrentDate = FusionUtils.CurrentTime;
-
-            Weather = World.Weather;
-            RainLevel = FusionUtils.RainLevel;
-            PuddleLevel = RainPuddleEditor.Level;
-
-            WantedLevel = Game.Player.WantedLevel;
-
-            VehicleReplicas = new List<VehicleReplica>();
-
-            TimeHandler.UsedVehiclesByPlayer.ForEach(x =>
-            {
-                if (x != FusionUtils.PlayerVehicle)
-                {
-                    VehicleReplicas.Add(new VehicleReplica(x));
-                }
-            });
-            MomentReplicas.Add(this);
+            Update();
         }
 
         public static MomentReplica SearchForMoment()
@@ -68,7 +47,7 @@ namespace FusionLibrary
 
         public bool IsNow()
         {
-            if (CurrentDate.Between(FusionUtils.CurrentTime.AddMinutes(-MomentDuration), FusionUtils.CurrentTime.AddMinutes(MomentDuration)))
+            if (CurrentDate.Between(FusionUtils.CurrentTime.AddMinutes(-10), FusionUtils.CurrentTime.AddMinutes(10)))
             {
                 return true;
             }
@@ -114,26 +93,36 @@ namespace FusionLibrary
 
         public void Apply()
         {
-            if (!Applied)
+            World.Weather = Weather;
+            RainPuddleEditor.Level = PuddleLevel;
+            FusionUtils.RainLevel = RainLevel;
+            Game.Player.WantedLevel = WantedLevel;
+
+            VehicleReplicas?.ForEach(x => TimeHandler.UsedVehiclesByPlayer.Add(x.Spawn(SpawnFlags.Default)));
+        }
+
+        public void Update()
+        {
+            CurrentDate = FusionUtils.CurrentTime;
+
+            if (!LockWeather)
             {
-                if (TransitionWeather)
-                {
-                    World.TransitionToWeather(Weather, 2);
-                    RainPuddleEditor.Level = PuddleLevel;
-                    FusionUtils.RainLevel = RainLevel;
-                }
-                else
-                {
-                    World.Weather = Weather;
-                    RainPuddleEditor.Level = PuddleLevel;
-                    FusionUtils.RainLevel = RainLevel;
-                }
-
-                Game.Player.WantedLevel = WantedLevel;
-
-                VehicleReplicas?.ForEach(x => TimeHandler.UsedVehiclesByPlayer.Add(x.Spawn(SpawnFlags.Default)));
-                Applied = true;
+                Weather = World.Weather;
+                RainLevel = FusionUtils.RainLevel;
+                PuddleLevel = RainPuddleEditor.Level;
             }
+
+            WantedLevel = Game.Player.WantedLevel;
+
+            VehicleReplicas = new List<VehicleReplica>();
+
+            TimeHandler.UsedVehiclesByPlayer.ForEach(x =>
+            {
+                if (x != FusionUtils.PlayerVehicle)
+                {
+                    VehicleReplicas.Add(new VehicleReplica(x));
+                }
+            });
         }
     }
 }

--- a/Time/TimeHandler.cs
+++ b/Time/TimeHandler.cs
@@ -139,6 +139,11 @@ namespace FusionLibrary
             UsedVehiclesByPlayer.Clear();
 
             FusionUtils.CurrentTime = destinationTime;
+            
+            MomentReplica.MomentReplicas?.ForEach(x =>
+                {
+                    x.Applied = false;
+                });
 
             MomentReplica momentReplica = MomentReplica.SearchForMoment();
 
@@ -148,10 +153,6 @@ namespace FusionLibrary
             }
             else
             {
-                MomentReplica.MomentReplicas?.ForEach(x =>
-                {
-                    x.Applied = false;
-                });
                 momentReplica.Apply();
             }
 

--- a/Time/TimeHandler.cs
+++ b/Time/TimeHandler.cs
@@ -21,7 +21,7 @@ namespace FusionLibrary
         public static bool IsNight { get; internal set; }
 
         public static bool TrafficVolumeYearBased { get; set; }
-
+        
         public static bool MissionTraffic = false;
 
         public static bool RealTime
@@ -132,7 +132,16 @@ namespace FusionLibrary
 
         public static void TimeTravelTo(DateTime destinationTime)
         {
-            new MomentReplica();
+            MomentReplica momentReplica = MomentReplica.SearchForMoment();
+
+            if (momentReplica == null)
+            {
+                MomentReplica.MomentReplicas.Add(new MomentReplica());
+            }
+            else
+            {
+                momentReplica.Update();
+            }
 
             FusionUtils.ClearWorld();
 
@@ -140,7 +149,7 @@ namespace FusionLibrary
 
             FusionUtils.CurrentTime = destinationTime;
 
-            MomentReplica momentReplica = MomentReplica.SearchForMoment();
+            momentReplica = MomentReplica.SearchForMoment();
 
             if (momentReplica == null)
             {
@@ -148,10 +157,6 @@ namespace FusionLibrary
             }
             else
             {
-                MomentReplica.MomentReplicas?.ForEach(x =>
-                {
-                    x.Applied = false;
-                });
                 momentReplica.Apply();
             }
 

--- a/Time/TimeHandler.cs
+++ b/Time/TimeHandler.cs
@@ -21,7 +21,7 @@ namespace FusionLibrary
         public static bool IsNight { get; internal set; }
 
         public static bool TrafficVolumeYearBased { get; set; }
-        
+
         public static bool MissionTraffic = false;
 
         public static bool RealTime
@@ -132,16 +132,7 @@ namespace FusionLibrary
 
         public static void TimeTravelTo(DateTime destinationTime)
         {
-            MomentReplica momentReplica = MomentReplica.SearchForMoment();
-
-            if (momentReplica == null)
-            {
-                MomentReplica.MomentReplicas.Add(new MomentReplica());
-            }
-            else
-            {
-                momentReplica.Update();
-            }
+            new MomentReplica();
 
             FusionUtils.ClearWorld();
 
@@ -149,7 +140,7 @@ namespace FusionLibrary
 
             FusionUtils.CurrentTime = destinationTime;
 
-            momentReplica = MomentReplica.SearchForMoment();
+            MomentReplica momentReplica = MomentReplica.SearchForMoment();
 
             if (momentReplica == null)
             {
@@ -157,6 +148,10 @@ namespace FusionLibrary
             }
             else
             {
+                MomentReplica.MomentReplicas?.ForEach(x =>
+                {
+                    x.Applied = false;
+                });
                 momentReplica.Apply();
             }
 


### PR DESCRIPTION
Updated MomentReplica to correct issues with existing entries in the MomentReplicas list being overwritten when a time machine departs, made it so that a MomentReplica can only be called once, reset this check whenever time travel is initiated, and added the ability to have moments with arbitrary durations.