### PR TITLE
Correct HP issues in PlayerSwitch, update nuspec to 1.5.1

### DIFF
--- a/FusionLibrary.nuspec
+++ b/FusionLibrary.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>FusionLibrary.SHVDN3</id>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
     <authors>MrFusion92</authors>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">MIT</license>

--- a/Other/PlayerSwitch.cs
+++ b/Other/PlayerSwitch.cs
@@ -26,7 +26,7 @@ namespace FusionLibrary
         private static int _health;
         private static bool _ragdoll;
 
-        public static void Switch(Ped to, bool forceShort, bool instant = false)
+        public static void Switch(Ped to, bool forceShort, bool instant = false, bool fullHealth = false)
         {
             _health = Function.Call<int>(Hash.GET_ENTITY_HEALTH, to);
             _ragdoll = to.IsRagdoll;
@@ -34,7 +34,10 @@ namespace FusionLibrary
             if (instant)
             {
                 Function.Call(Hash.CHANGE_PLAYER_PED, Game.Player, to, false, false);
-                Function.Call(Hash.SET_ENTITY_HEALTH, Game.Player.Character, _health);
+                if (!fullHealth)
+                {
+                    Function.Call(Hash.SET_ENTITY_HEALTH, Game.Player.Character, _health);
+                }
 
                 if (_ragdoll)
                 {
@@ -60,15 +63,24 @@ namespace FusionLibrary
 
             Function.Call(Hash.START_PLAYER_SWITCH, Game.Player.Character, To, 1024, SwitchType);
             Function.Call(Hash.CHANGE_PLAYER_PED, Game.Player, To, false, false);
+            if (!fullHealth)
+            {
+                Function.Call(Hash.SET_ENTITY_HEALTH, Game.Player.Character, _health);
+            }
 
             OnSwitchingStart?.Invoke();
         }
 
-        public static Ped CreatePedAndSwitch(out Ped originalPed, Vector3 pos, float heading, bool forceShort, bool instant = false)
+        public static Ped CreatePedAndSwitch(out Ped originalPed, Vector3 pos, float heading, bool forceShort, bool instant = false, bool fullHealth = false)
         {
             originalPed = Game.Player.Character;
 
             Ped clone = World.CreatePed(Game.Player.Character.Model, pos, heading);
+
+            if (!fullHealth)
+            {
+                clone.Health = originalPed.Health;
+            }
 
             Function.Call(Hash.CLONE_PED_TO_TARGET, Game.Player.Character, clone);
 

--- a/Other/PlayerSwitch.cs
+++ b/Other/PlayerSwitch.cs
@@ -26,7 +26,7 @@ namespace FusionLibrary
         private static int _health;
         private static bool _ragdoll;
 
-        public static void Switch(Ped to, bool forceShort, bool instant = false)
+        public static void Switch(Ped to, bool forceShort, bool instant = false, bool fullHealth = false)
         {
             _health = Function.Call<int>(Hash.GET_ENTITY_HEALTH, to);
             _ragdoll = to.IsRagdoll;

--- a/Other/PlayerSwitch.cs
+++ b/Other/PlayerSwitch.cs
@@ -26,7 +26,7 @@ namespace FusionLibrary
         private static int _health;
         private static bool _ragdoll;
 
-        public static void Switch(Ped to, bool forceShort, bool instant = false, bool fullHealth = false)
+        public static void Switch(Ped to, bool forceShort, bool instant = false)
         {
             _health = Function.Call<int>(Hash.GET_ENTITY_HEALTH, to);
             _ragdoll = to.IsRagdoll;
@@ -34,10 +34,7 @@ namespace FusionLibrary
             if (instant)
             {
                 Function.Call(Hash.CHANGE_PLAYER_PED, Game.Player, to, false, false);
-                if (!fullHealth)
-                {
-                    Function.Call(Hash.SET_ENTITY_HEALTH, Game.Player.Character, _health);
-                }
+                Function.Call(Hash.SET_ENTITY_HEALTH, Game.Player.Character, _health);
 
                 if (_ragdoll)
                 {


### PR DESCRIPTION
Corrects an issue with PlayerSwitch where HP level is not consistent and offer an optional boolean parameter so scripts can use the old method if desired. Also updated nuspec to 1.5.1 to account for the latest code changes since 1.5.0.