### PR TITLE
Update MomentReplica to better handle wanted levels

### DIFF
--- a/Replica/MomentReplica.cs
+++ b/Replica/MomentReplica.cs
@@ -21,6 +21,8 @@ namespace FusionLibrary
 
         public bool TransitionWeather { get; set; } = false;
 
+        public bool ResetWanted { get; set; } = true;
+
         public bool Applied = false;
 
         public double MomentDuration { get; set; } = 10;
@@ -129,7 +131,10 @@ namespace FusionLibrary
                     FusionUtils.RainLevel = RainLevel;
                 }
 
-                Game.Player.WantedLevel = WantedLevel;
+                if (ResetWanted)
+                {
+                    Game.Player.WantedLevel = WantedLevel;
+                }
 
                 VehicleReplicas?.ForEach(x => TimeHandler.UsedVehiclesByPlayer.Add(x.Spawn(SpawnFlags.Default)));
                 Applied = true;

--- a/Traffic/ModelSwap.cs
+++ b/Traffic/ModelSwap.cs
@@ -136,7 +136,7 @@ namespace FusionLibrary
                 {
                     vehicles = vehicles.Where(x => x.Model != baseModel && !x.Decorator().ModelSwapped && ((SwapOnlyDesiredModels && swapModels.Contains(x.Model)) || (!SwapOnlyDesiredModels && x.Type == VehicleType && x.ClassType == VehicleClass))).SelectRandomElements(tempMax - count);
 
-                    //GTA.UI.Screen.ShowSubtitle($"{chanceMulti} {count} {tempMax} {vehicles.Count()}");
+                    //GTA.UI.Screen.ShowSubtitle($"{chanceMulti} {count} {tempMax} {vehicles.Count()} {endTime} {DateBased}");
 
                     foreach (Vehicle vehicle in vehicles)
                     {


### PR DESCRIPTION
Added bool parameter to allow a MomentReplica to define whether to reset the player's wanted level, which can be useful for weather events that should not alter a player's wanted level. Defaults to true for functions that expect the original behavior.