### PR TITLE
Remove Yield from LoadAndRequestModel

### DIFF
--- a/FusionUtils.cs
+++ b/FusionUtils.cs
@@ -117,12 +117,6 @@ namespace FusionLibrary
             }
 
             model.Request();
-
-            while (!model.IsLoaded)
-            {
-                Script.Yield();
-            }
-
             return model;
         }
                 


### PR DESCRIPTION
Removed mandatory Yield from LoadAndRequestModel as processes which attempt to load large batches of models all at once would thus be calling Yield potentially tens or hundreds of times simultaneously. With this change, external scripts must perform their own yield to prevent null object references from creeping up due to models that have not loaded yet.