### PR TITLE
Fix ClearPanel() to fully clear values

### DIFF
--- a/GUI/InstrumentalMenu.cs
+++ b/GUI/InstrumentalMenu.cs
@@ -60,6 +60,9 @@ namespace FusionLibrary
         public void ClearPanel()
         {
             CallFunction("SET_DATA_SLOT_EMPTY");
+            CallFunction("CLEAR_ALL");
+            CallFunction("TOGGLE_MOUSE_BUTTONS", 0);
+            CallFunction("CREATE_CONTAINER");
         }
 
         private void SetButtons()


### PR DESCRIPTION
Added additional function calls in order to properly clear the instructional panel's button cache, which fixes displaying an InstrumentalMenu after a GTAV native instructional panel has been displayed not displaying correctly.