### PR TITLE
Fix warnings, expand VehicleReplica, add LICENSE

### DIFF
--- a/Extensions/EntityExtensions.cs
+++ b/Extensions/EntityExtensions.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using static FusionLibrary.FusionEnums;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace FusionLibrary.Extensions
 {

--- a/FusionLibrary.csproj
+++ b/FusionLibrary.csproj
@@ -39,7 +39,7 @@
     <OutputPath>bin\x64\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DocumentationFile>bin\Debug\FusionLibrary.xml</DocumentationFile>
+    <DocumentationFile>bin\x64\Debug\FusionLibrary.xml</DocumentationFile>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>7.3</LangVersion>
@@ -49,7 +49,7 @@
     <OutputPath>bin\x64\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DocumentationFile>bin\Release\FusionLibrary.xml</DocumentationFile>
+    <DocumentationFile>bin\x64\Release\FusionLibrary.xml</DocumentationFile>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>

--- a/FusionLibrary.sln
+++ b/FusionLibrary.sln
@@ -8,13 +8,19 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Debug|x64.ActiveCfg = Debug|x64
+		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Debug|x64.Build.0 = Debug|x64
 		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Release|x64.ActiveCfg = Release|x64
+		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 MrFusion92
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Replica/VehicleReplica.cs
+++ b/Replica/VehicleReplica.cs
@@ -15,7 +15,15 @@ namespace FusionLibrary
         public bool EngineRunning { get; }
         public VehicleColor PrimaryColor { get; }
         public VehicleColor SecondaryColor { get; }
+        public VehicleColor InteriorColor { get; }
+        public VehicleColor DashboardColor { get; }
+        public VehicleColor WheelColor { get; }
+        public VehicleWheelType WheelType { get; }
+        public LicensePlateStyle PlateStyle { get; }
+        public string PlateNumber { get; }
+        public VehicleWindowTint WindowTint { get; }
         public int Livery { get; }
+        public List<bool> Extras { get; }
         public List<PedReplica> Occupants { get; }
 
         public float Handbrake { get; }
@@ -35,9 +43,23 @@ namespace FusionLibrary
         {
             EngineHealth = vehicle.EngineHealth;
             EngineRunning = vehicle.IsEngineRunning;
+            WheelType = vehicle.Mods.WheelType;
             PrimaryColor = vehicle.Mods.PrimaryColor;
             SecondaryColor = vehicle.Mods.SecondaryColor;
+            InteriorColor = vehicle.Mods.TrimColor;
+            DashboardColor = vehicle.Mods.DashboardColor;
+            WheelColor = vehicle.Mods.RimColor;
+            PlateStyle = vehicle.Mods.LicensePlateStyle;
+            PlateNumber = vehicle.Mods.LicensePlate;
+            WindowTint = vehicle.Mods.WindowTint;
             Livery = vehicle.Mods.Livery;
+
+            Extras = new List<bool>();
+
+            for (int x = 1; x <= 13; x++)
+            {
+                Extras.Add(vehicle.IsExtraOn(x));
+            }
 
             RPM = vehicle.CurrentRPM;
             Gear = vehicle.CurrentGear;
@@ -118,9 +140,21 @@ namespace FusionLibrary
 
             vehicle.HealthFloat = Health;
             vehicle.EngineHealth = EngineHealth;
+            vehicle.Mods.WheelType = WheelType;
             vehicle.Mods.PrimaryColor = PrimaryColor;
             vehicle.Mods.SecondaryColor = SecondaryColor;
+            vehicle.Mods.TrimColor = InteriorColor;
+            vehicle.Mods.DashboardColor = DashboardColor;
+            vehicle.Mods.RimColor = WheelColor;
+            vehicle.Mods.LicensePlateStyle = PlateStyle;
+            vehicle.Mods.LicensePlate = PlateNumber;
+            vehicle.Mods.WindowTint = WindowTint;
             vehicle.Mods.Livery = Livery;
+
+            for (int x = 0; x < 13; x++)
+            {
+                vehicle.ToggleExtra(x+1, Extras[x]);
+            }
 
             vehicle.IsEngineRunning = EngineRunning;
 

--- a/Replica/VehicleReplica.cs
+++ b/Replica/VehicleReplica.cs
@@ -24,6 +24,7 @@ namespace FusionLibrary
         public VehicleWindowTint WindowTint { get; }
         public int Livery { get; }
         public List<bool> Extras { get; }
+        public List<int> Mods { get; }
         public List<PedReplica> Occupants { get; }
 
         public float Handbrake { get; }
@@ -59,6 +60,13 @@ namespace FusionLibrary
             for (int x = 1; x <= 13; x++)
             {
                 Extras.Add(vehicle.IsExtraOn(x));
+            }
+
+            Mods = new List<int>();
+
+            foreach (VehicleModType x in (VehicleModType[])Enum.GetValues(typeof(VehicleModType)))
+            {
+                Mods.Add(vehicle.Mods[x].Index);
             }
 
             RPM = vehicle.CurrentRPM;
@@ -154,6 +162,11 @@ namespace FusionLibrary
             for (int x = 0; x < 13; x++)
             {
                 vehicle.ToggleExtra(x+1, Extras[x]);
+            }
+
+            for (int x = 0; x < Mods.Count; x++)
+            {
+                vehicle.Mods[(VehicleModType)x].Index = Mods[x];
             }
 
             vehicle.IsEngineRunning = EngineRunning;


### PR DESCRIPTION
Suppressed obsolete warning for Wheels.Index in EntityExtensions.cs, fixed incorrect documentation directory definitions in csproj, added x64 CPU parameters in solution to clear compiler errors, expanded VehicleReplica to support license plate style and text, interior and dashboard colors, wheel type and color, window tint amount, and extras. Also added LICENSE file to match current nuget license information.