### PR TITLE
Add NoMods SpawnFlag for VehicleReplica

### DIFF
--- a/Event/TimedEvent.cs
+++ b/Event/TimedEvent.cs
@@ -148,7 +148,7 @@ namespace FusionLibrary
         }
 
         private void CalculateCurrentFloat()
-        {            
+        {
             CurrentFloat += ((EndFloat - StartFloat) / (float)Duration.TotalSeconds) * Game.LastFrameTime;
         }
 

--- a/FusionEnums.cs
+++ b/FusionEnums.cs
@@ -104,7 +104,8 @@ namespace FusionLibrary
             NoVelocity = 128,
             New = 256,
             SetRotation = 512,
-            NoWheels = 1024
+            NoWheels = 1024,
+            NoMods = 2048
         }
 
         /// <summary>

--- a/Replica/VehicleReplica.cs
+++ b/Replica/VehicleReplica.cs
@@ -55,18 +55,21 @@ namespace FusionLibrary
             WindowTint = vehicle.Mods.WindowTint;
             Livery = vehicle.Mods.Livery;
 
-            Extras = new List<bool>();
-
-            for (int x = 1; x <= 13; x++)
+            if (!spawnFlags.HasFlag(SpawnFlags.NoMods))
             {
-                Extras.Add(vehicle.IsExtraOn(x));
-            }
+                Extras = new List<bool>();
 
-            Mods = new List<int>();
+                for (int x = 1; x <= 13; x++)
+                {
+                    Extras.Add(vehicle.IsExtraOn(x));
+                }
 
-            foreach (VehicleModType x in (VehicleModType[])Enum.GetValues(typeof(VehicleModType)))
-            {
-                Mods.Add(vehicle.Mods[x].Index);
+                Mods = new List<int>();
+
+                foreach (VehicleModType x in (VehicleModType[])Enum.GetValues(typeof(VehicleModType)))
+                {
+                    Mods.Add(vehicle.Mods[x].Index);
+                }
             }
 
             RPM = vehicle.CurrentRPM;
@@ -159,14 +162,23 @@ namespace FusionLibrary
             vehicle.Mods.WindowTint = WindowTint;
             vehicle.Mods.Livery = Livery;
 
-            for (int x = 0; x < 13; x++)
+            if (Extras != null)
             {
-                vehicle.ToggleExtra(x+1, Extras[x]);
-            }
+                for (int x = 0; x < 13; x++)
+                {
+                    if (vehicle.IsExtraOn(x + 1) != Extras[x])
+                    {
+                        vehicle.ToggleExtra(x + 1, Extras[x]);
+                    }
+                }
 
-            for (int x = 0; x < Mods.Count; x++)
-            {
-                vehicle.Mods[(VehicleModType)x].Index = Mods[x];
+                for (int x = 0; x < Mods.Count; x++)
+                {
+                    if (vehicle.Mods[(VehicleModType)x].Index != Mods[x])
+                    {
+                        vehicle.Mods[(VehicleModType)x].Index = Mods[x];
+                    }
+                }
             }
 
             vehicle.IsEngineRunning = EngineRunning;


### PR DESCRIPTION
Adds a SpawnFlag to prevent VehicleReplica from interacting with a vehicle's Mods or Extras list. Used for situations where the target vehicle already has Extras and Mods that are under direct control of a running script and as such VehicleReplica attempting to apply them would cause a conflict as both scripts attempt to change the same parameters every single frame.