### PR TITLE
Add Large & SuperLarge Render Targets

### DIFF
--- a/GUI/ScaleformGui.cs
+++ b/GUI/ScaleformGui.cs
@@ -23,6 +23,8 @@ namespace FusionLibrary
         public bool IsLoaded => Function.Call<bool>(Hash.HAS_SCALEFORM_MOVIE_LOADED, Handle);
 
         public bool DrawInPauseMenu { get; set; }
+        public bool UseLargeRt { get; set; }
+        public bool UseSuperLargeRt { get; set; }
 
         private int _handle;
 
@@ -80,12 +82,24 @@ namespace FusionLibrary
         {
             Function.Call(Hash.SET_SCRIPT_GFX_DRAW_BEHIND_PAUSEMENU, DrawInPauseMenu);
 
+            // SET_SCALEFORM_MOVIE_TO_USE_LARGE_RT
+            Function.Call((Hash)0x32F34FF7F617643B, Handle, UseLargeRt);
+
+            // SET_SCALEFORM_MOVIE_TO_USE_SUPER_LARGE_RT
+            Function.Call((Hash)0xE6A9F00D4240B519, Handle, UseSuperLargeRt);
+
             Function.Call(Hash.DRAW_SCALEFORM_MOVIE_FULLSCREEN, Handle, 255, 255, 255, 255, 0);
         }
 
         public void Render2D(PointF location, float scale)
         {
             Function.Call(Hash.SET_SCRIPT_GFX_DRAW_BEHIND_PAUSEMENU, DrawInPauseMenu);
+
+            // SET_SCALEFORM_MOVIE_TO_USE_LARGE_RT
+            Function.Call((Hash)0x32F34FF7F617643B, Handle, UseLargeRt);
+
+            // SET_SCALEFORM_MOVIE_TO_USE_SUPER_LARGE_RT
+            Function.Call((Hash)0xE6A9F00D4240B519, Handle, UseSuperLargeRt);
 
             Function.Call(Hash.DRAW_SCALEFORM_MOVIE, Handle, location.X, location.Y, scale, scale, 255, 255, 255, 255, 0);
         }
@@ -94,6 +108,12 @@ namespace FusionLibrary
         {
             Function.Call(Hash.SET_SCRIPT_GFX_DRAW_BEHIND_PAUSEMENU, DrawInPauseMenu);
 
+            // SET_SCALEFORM_MOVIE_TO_USE_LARGE_RT
+            Function.Call((Hash)0x32F34FF7F617643B, Handle, UseLargeRt);
+
+            // SET_SCALEFORM_MOVIE_TO_USE_SUPER_LARGE_RT
+            Function.Call((Hash)0xE6A9F00D4240B519, Handle, UseSuperLargeRt);
+
             Function.Call(Hash.DRAW_SCALEFORM_MOVIE, Handle, location.X, location.Y, size.Width, size.Height, 0, 0, 0, 0, 0);
         }
 
@@ -101,12 +121,24 @@ namespace FusionLibrary
         {
             Function.Call(Hash.SET_SCRIPT_GFX_DRAW_BEHIND_PAUSEMENU, DrawInPauseMenu);
 
+            // SET_SCALEFORM_MOVIE_TO_USE_LARGE_RT
+            Function.Call((Hash)0x32F34FF7F617643B, Handle, UseLargeRt);
+
+            // SET_SCALEFORM_MOVIE_TO_USE_SUPER_LARGE_RT
+            Function.Call((Hash)0xE6A9F00D4240B519, Handle, UseSuperLargeRt);
+            
             Function.Call(Hash.DRAW_SCALEFORM_MOVIE_3D_SOLID, Handle, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, 2.0f, 2.0f, 1.0f, scale.X, scale.Y, scale.Z, 2);
         }
 
         public void Render3DAdditive(Vector3 position, Vector3 rotation, Vector3 scale)
         {
             Function.Call(Hash.SET_SCRIPT_GFX_DRAW_BEHIND_PAUSEMENU, DrawInPauseMenu);
+
+            // SET_SCALEFORM_MOVIE_TO_USE_LARGE_RT
+            Function.Call((Hash)0x32F34FF7F617643B, Handle, UseLargeRt);
+
+            // SET_SCALEFORM_MOVIE_TO_USE_SUPER_LARGE_RT
+            Function.Call((Hash)0xE6A9F00D4240B519, Handle, UseSuperLargeRt);
 
             Function.Call(Hash.DRAW_SCALEFORM_MOVIE_3D, Handle, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, 2.0f, 2.0f, 1.0f, scale.X, scale.Y, scale.Z, 2);
         }


### PR DESCRIPTION
Adds ability to call native Large and SuperLarge render targets for scaleforms, allowing much larger output texture resolutions than without these natives called.