### PR TITLE
AnimateProp update, cleanup

### DIFF
--- a/Memory/VehicleControl.cs
+++ b/Memory/VehicleControl.cs
@@ -56,7 +56,7 @@ namespace FusionLibrary.Memory
             deluxoFlyModeOffset = deluxoTransformationOffset == 0 ? 0 : deluxoTransformationOffset + 4;
 
             addr = MemoryFunctions.FindPattern("\x44\x0F\x2F\x43\x48\x45\x8D", "xxxxxxx");
-            drawHandlerPtrOffset = addr == null ? 0 : *(byte*)(addr + 4);
+            drawHandlerPtrOffset = addr == null ? 0 : *(addr + 4);
 
             addr = MemoryFunctions.FindPattern("\x4C\x8D\x48\x00\x80\xE1\x01", "xxx?xxx");
             streamRenderGfxPtrOffset = addr == null ? 0 : *(int*)(addr - 4);
@@ -103,6 +103,45 @@ namespace FusionLibrary.Memory
             }
 
             return *(float*)(CVeh_0x48_0x370 + 0x8);
+        }
+
+        // note, visual only.
+        public static void SetWheelWidth(Vehicle vehicle, float width)
+        {
+            IntPtr? address = vehicle?.MemoryAddress;
+
+            if (address == IntPtr.Zero)
+            {
+                return;
+            }
+
+            ulong drawHandler = *(ulong*)(address + drawHandlerPtrOffset);
+            ulong streamRenderGfx = *(ulong*)(drawHandler + (uint)streamRenderGfxPtrOffset);
+
+            if (streamRenderGfx != 0 && width != 0.0f)
+            {
+                *(float*)(streamRenderGfx + (uint)streamRenderWheelWidthOffset) = width;
+            }
+        }
+
+        public static float GetWheelWidth(Vehicle vehicle)
+        {
+            IntPtr? address = vehicle?.MemoryAddress;
+
+            if (address == IntPtr.Zero)
+            {
+                return 0.0f;
+            }
+
+            ulong drawHandler = *(ulong*)(address + drawHandlerPtrOffset);
+            ulong streamRenderGfx = *(ulong*)(drawHandler + (uint)streamRenderGfxPtrOffset);
+
+            if (streamRenderGfx != 0)
+            {
+                return *(float*)(streamRenderGfx + (uint)streamRenderWheelWidthOffset);
+            }
+
+            return 0.0f;
         }
 
         public static ulong GetHandlingPtr(Vehicle vehicle)
@@ -466,45 +505,6 @@ namespace FusionLibrary.Memory
             brake = Game.IsControlJustPressed(Control.MoveDown);
             float left = Game.GetDisabledControlValueNormalized(Control.MoveLeft).Remap(0, 1f, 0, limitRadians);
             steer = -left;
-        }
-
-        // note, visual only.
-        public static void SetWheelWidth(Vehicle vehicle, float width)
-        {
-	        IntPtr? address = vehicle?.MemoryAddress;
-
-	        if (address == IntPtr.Zero)
-	        {
-		        return;
-	        }
-
-	        ulong drawHandler = *(ulong*)(address + drawHandlerPtrOffset);
-			ulong streamRenderGfx = *(ulong*)(drawHandler + (uint)streamRenderGfxPtrOffset);
-
-			if (streamRenderGfx != 0 && width != 0.0f)
-			{
-				*(float*)(streamRenderGfx + (uint)streamRenderWheelWidthOffset) = width;
-			}
-		}
-
-        public static float GetWheelWidth(Vehicle vehicle)
-        {
-	        IntPtr? address = vehicle?.MemoryAddress;
-
-	        if (address == IntPtr.Zero)
-	        {
-		        return 0.0f;
-	        }
-
-	        ulong drawHandler = *(ulong*)(address + drawHandlerPtrOffset);
-	        ulong streamRenderGfx = *(ulong*)(drawHandler + (uint)streamRenderGfxPtrOffset);
-
-	        if (streamRenderGfx != 0)
-	        {
-		        return *(float*)(streamRenderGfx + (uint)streamRenderWheelWidthOffset);
-	        }
-
-            return 0.0f;
         }
     }
 }

--- a/Prop/AnimateProp.cs
+++ b/Prop/AnimateProp.cs
@@ -229,7 +229,7 @@ namespace FusionLibrary
                 {
                     Prop.IsVisible = value;
                 }
-                else if(value)
+                else if (value == true)
                 {
                     SpawnProp();
                 }
@@ -388,7 +388,7 @@ namespace FusionLibrary
             Model = model;
             Prop?.Delete();
 
-            if (IsSpawned)
+            if (Visible)
             {
                 SpawnProp();
             }

--- a/Prop/AnimateProp.cs
+++ b/Prop/AnimateProp.cs
@@ -229,7 +229,7 @@ namespace FusionLibrary
                 {
                     Prop.IsVisible = value;
                 }
-                else if (value == true)
+                else if (value)
                 {
                     SpawnProp();
                 }

--- a/Prop/AnimatePropsHandler.cs
+++ b/Prop/AnimatePropsHandler.cs
@@ -144,7 +144,7 @@ namespace FusionLibrary
                     }
                     else
                     {
-                        Delete();
+                        Visible = false;
 
                         OnSequenceCompleted?.Invoke(false);
                         return;
@@ -153,7 +153,7 @@ namespace FusionLibrary
 
                 if (currentSequenceProp > -1)
                 {
-                    Props[currentSequenceProp]?.Delete();
+                    Props[currentSequenceProp].Visible = false;
                 }
 
                 if (playedProps.Count == 0)
@@ -165,7 +165,7 @@ namespace FusionLibrary
                     currentSequenceProp = FusionUtils.Random.NextExcept(0, Count, currentSequenceProp);
                 }
 
-                Props[currentSequenceProp]?.SpawnProp();
+                Props[currentSequenceProp].Visible = true;
 
                 playedProps.Add(currentSequenceProp);
 
@@ -178,14 +178,14 @@ namespace FusionLibrary
             {
                 if (IsSequenceLooped)
                 {
-                    Props[currentSequenceProp]?.Delete();
+                    Props[currentSequenceProp].Visible = false;
 
                     currentSequenceProp = -1;
                     playedProps.Clear();
                 }
                 else
                 {
-                    Delete();
+                    Visible = false;
 
                     OnSequenceCompleted?.Invoke(false);
                     return;
@@ -194,12 +194,12 @@ namespace FusionLibrary
 
             if (currentSequenceProp > -1)
             {
-                Props[currentSequenceProp]?.Delete();
+                Props[currentSequenceProp].Visible = false;
             }
 
             currentSequenceProp++;
 
-            Props[currentSequenceProp]?.SpawnProp();
+            Props[currentSequenceProp].Visible = true;
 
             playedProps.Add(currentSequenceProp);
 


### PR DESCRIPTION
Fixed sequences in AnimatePropsHandler to use visible property instead of Spawning/Deleting, made it so only setting a prop to visible will spawn it as we shouldn't spawn a non-visible prop, made it so SwapModel will only spawn the prop if it was previously visible, and cleaned up code in VehicleControl to remove unnecessary cast and move SetWheelWidth to be next to SetWheelSize where it makes more sense.