### PR TITLE
Update native hashes

### DIFF
--- a/Event/TimedEvent.cs
+++ b/Event/TimedEvent.cs
@@ -198,7 +198,7 @@ namespace FusionLibrary
             }
 
             //Disable fake shake of the cars.
-            Function.Call((Hash)0x84FD40F56075E816, 0);
+            Function.Call(Hash.SET_CAR_HIGH_SPEED_BUMP_SEVERITY_MULTIPLIER, 0);
         }
 
         public bool Run(TimeSpan tCurrentTime, bool tManageCamera = false)

--- a/Extensions/EntityExtensions.cs
+++ b/Extensions/EntityExtensions.cs
@@ -883,7 +883,7 @@ namespace FusionLibrary.Extensions
         /// <param name="state">State of the lights.</param>
         public static void SetPlayerLights(this Vehicle vehicle, bool state)
         {
-            Function.Call((Hash)0xC45C27EF50F36ADC, vehicle, state);
+            Function.Call(Hash.SET_VEHICLE_USE_PLAYER_LIGHT_SETTINGS, vehicle, state);
         }
 
         /// <summary>

--- a/FusionUtils.cs
+++ b/FusionUtils.cs
@@ -181,7 +181,7 @@ namespace FusionLibrary
             else
                 Function.Call(Hash.SET_ALL_VEHICLE_GENERATORS_ACTIVE_IN_AREA, -10000.0f, -10000.0f, -1000.0f, 10000.0f, 10000.0f, 1000.0f, 0, 1);
 
-            Function.Call((Hash)0xF796359A959DF65D, state);
+            Function.Call(Hash.SET_DISTANT_CARS_ENABLED, state);
             Function.Call(Hash.DISABLE_VEHICLE_DISTANTLIGHTS, !state);
 
             _trafficAlive = state;
@@ -196,7 +196,7 @@ namespace FusionLibrary
         {
             OutputArgument ret = new OutputArgument();
 
-            Function.Call((Hash)0x16F46FB18C8009E4, position.X, position.Y, position.Z, -1, ret);
+            Function.Call(Hash.GET_POSITION_BY_SIDE_OF_ROAD, position.X, position.Y, position.Z, -1, ret);
 
             return ret.GetResult<Vector3>();
         }
@@ -676,21 +676,21 @@ namespace FusionLibrary
         /// <returns><see langword="true"/> if FPV is enabled; otherwise <see langword="false"/>.</returns>
         public static bool IsCameraInFirstPerson()
         {
-            return Function.Call<int>(Hash.GET_FOLLOW_PED_CAM_VIEW_MODE) == 4 && !GameplayCamera.IsLookingBehind && !Function.Call<bool>((Hash)0xF5F1E89A970B7796);
+            return Function.Call<int>(Hash.GET_FOLLOW_PED_CAM_VIEW_MODE) == 4 && !GameplayCamera.IsLookingBehind && !Function.Call<bool>(Hash.IS_CINEMATIC_CAM_INPUT_ACTIVE);
         }
 
         public static float RainLevel
         {
-            get => Function.Call<float>((Hash)0x96695E368AD855F3);
+            get => Function.Call<float>(Hash.GET_RAIN_LEVEL);
 
-            set => Function.Call((Hash)0x643E26EA6E024D92, value);
+            set => Function.Call(Hash.SET_RAIN, value);
         }
 
         public static float WindSpeed
         {
-            get => Function.Call<float>((Hash)0xA8CF1CC0AFCD3F12);
+            get => Function.Call<float>(Hash.GET_WIND_SPEED);
 
-            set => Function.Call((Hash)0xEE09ECEDBABE47FC, value);
+            set => Function.Call(Hash.SET_WIND_SPEED, value);
         }
 
         public static float Magnitude(Vector3 vector3)

--- a/GUI/ScaleformGui.cs
+++ b/GUI/ScaleformGui.cs
@@ -83,10 +83,10 @@ namespace FusionLibrary
             Function.Call(Hash.SET_SCRIPT_GFX_DRAW_BEHIND_PAUSEMENU, DrawInPauseMenu);
 
             // SET_SCALEFORM_MOVIE_TO_USE_LARGE_RT
-            Function.Call((Hash)0x32F34FF7F617643B, Handle, UseLargeRt);
+            Function.Call(Hash.SET_SCALEFORM_MOVIE_TO_USE_LARGE_RT, Handle, UseLargeRt);
 
             // SET_SCALEFORM_MOVIE_TO_USE_SUPER_LARGE_RT
-            Function.Call((Hash)0xE6A9F00D4240B519, Handle, UseSuperLargeRt);
+            Function.Call(Hash.SET_SCALEFORM_MOVIE_TO_USE_SUPER_LARGE_RT, Handle, UseSuperLargeRt);
 
             Function.Call(Hash.DRAW_SCALEFORM_MOVIE_FULLSCREEN, Handle, 255, 255, 255, 255, 0);
         }
@@ -96,10 +96,10 @@ namespace FusionLibrary
             Function.Call(Hash.SET_SCRIPT_GFX_DRAW_BEHIND_PAUSEMENU, DrawInPauseMenu);
 
             // SET_SCALEFORM_MOVIE_TO_USE_LARGE_RT
-            Function.Call((Hash)0x32F34FF7F617643B, Handle, UseLargeRt);
+            Function.Call(Hash.SET_SCALEFORM_MOVIE_TO_USE_LARGE_RT, Handle, UseLargeRt);
 
             // SET_SCALEFORM_MOVIE_TO_USE_SUPER_LARGE_RT
-            Function.Call((Hash)0xE6A9F00D4240B519, Handle, UseSuperLargeRt);
+            Function.Call(Hash.SET_SCALEFORM_MOVIE_TO_USE_SUPER_LARGE_RT, Handle, UseSuperLargeRt);
 
             Function.Call(Hash.DRAW_SCALEFORM_MOVIE, Handle, location.X, location.Y, scale, scale, 255, 255, 255, 255, 0);
         }
@@ -109,10 +109,10 @@ namespace FusionLibrary
             Function.Call(Hash.SET_SCRIPT_GFX_DRAW_BEHIND_PAUSEMENU, DrawInPauseMenu);
 
             // SET_SCALEFORM_MOVIE_TO_USE_LARGE_RT
-            Function.Call((Hash)0x32F34FF7F617643B, Handle, UseLargeRt);
+            Function.Call(Hash.SET_SCALEFORM_MOVIE_TO_USE_LARGE_RT, Handle, UseLargeRt);
 
             // SET_SCALEFORM_MOVIE_TO_USE_SUPER_LARGE_RT
-            Function.Call((Hash)0xE6A9F00D4240B519, Handle, UseSuperLargeRt);
+            Function.Call(Hash.SET_SCALEFORM_MOVIE_TO_USE_SUPER_LARGE_RT, Handle, UseSuperLargeRt);
 
             Function.Call(Hash.DRAW_SCALEFORM_MOVIE, Handle, location.X, location.Y, size.Width, size.Height, 0, 0, 0, 0, 0);
         }
@@ -122,10 +122,10 @@ namespace FusionLibrary
             Function.Call(Hash.SET_SCRIPT_GFX_DRAW_BEHIND_PAUSEMENU, DrawInPauseMenu);
 
             // SET_SCALEFORM_MOVIE_TO_USE_LARGE_RT
-            Function.Call((Hash)0x32F34FF7F617643B, Handle, UseLargeRt);
+            Function.Call(Hash.SET_SCALEFORM_MOVIE_TO_USE_LARGE_RT, Handle, UseLargeRt);
 
             // SET_SCALEFORM_MOVIE_TO_USE_SUPER_LARGE_RT
-            Function.Call((Hash)0xE6A9F00D4240B519, Handle, UseSuperLargeRt);
+            Function.Call(Hash.SET_SCALEFORM_MOVIE_TO_USE_SUPER_LARGE_RT, Handle, UseSuperLargeRt);
 
             Function.Call(Hash.DRAW_SCALEFORM_MOVIE_3D_SOLID, Handle, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, 2.0f, 2.0f, 1.0f, scale.X, scale.Y, scale.Z, 2);
         }
@@ -135,10 +135,10 @@ namespace FusionLibrary
             Function.Call(Hash.SET_SCRIPT_GFX_DRAW_BEHIND_PAUSEMENU, DrawInPauseMenu);
 
             // SET_SCALEFORM_MOVIE_TO_USE_LARGE_RT
-            Function.Call((Hash)0x32F34FF7F617643B, Handle, UseLargeRt);
+            Function.Call(Hash.SET_SCALEFORM_MOVIE_TO_USE_LARGE_RT, Handle, UseLargeRt);
 
             // SET_SCALEFORM_MOVIE_TO_USE_SUPER_LARGE_RT
-            Function.Call((Hash)0xE6A9F00D4240B519, Handle, UseSuperLargeRt);
+            Function.Call(Hash.SET_SCALEFORM_MOVIE_TO_USE_SUPER_LARGE_RT, Handle, UseSuperLargeRt);
 
             Function.Call(Hash.DRAW_SCALEFORM_MOVIE_3D, Handle, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, 2.0f, 2.0f, 1.0f, scale.X, scale.Y, scale.Z, 2);
         }

--- a/Other/DoorHandler.cs
+++ b/Other/DoorHandler.cs
@@ -18,79 +18,79 @@ namespace FusionLibrary
 
         public static void RemoveDoor(GarageDoor garageDoor)
         {
-            Function.Call((Hash)0x464D8E1427156FE4, garageDoor);
+            Function.Call(Hash.REMOVE_DOOR_FROM_SYSTEM, garageDoor);
         }
 
         public static void RemoveDoor(Hash door)
         {
-            Function.Call((Hash)0x464D8E1427156FE4, door);
+            Function.Call(Hash.REMOVE_DOOR_FROM_SYSTEM, door);
         }
 
         public static bool IsDoorRegistered(GarageDoor garageDoor)
         {
-            return Function.Call<bool>((Hash)0xC153C43EA202C8C1, garageDoor);
+            return Function.Call<bool>(Hash.IS_DOOR_REGISTERED_WITH_SYSTEM, garageDoor);
         }
 
         public static bool IsDoorRegistered(Hash door)
         {
-            return Function.Call<bool>((Hash)0xC153C43EA202C8C1, door);
+            return Function.Call<bool>(Hash.IS_DOOR_REGISTERED_WITH_SYSTEM, door);
         }
 
         public static bool IsDoorClosed(GarageDoor door)
         {
-            return Function.Call<bool>((Hash)0xC531EE8A1145A149, door);
+            return Function.Call<bool>(Hash.IS_DOOR_CLOSED, door);
         }
 
         public static bool IsDoorClosed(Hash door)
         {
-            return Function.Call<bool>((Hash)0xC531EE8A1145A149, door);
+            return Function.Call<bool>(Hash.IS_DOOR_CLOSED, door);
         }
 
         public static float GetDoorOpenRatio(Hash door)
         {
-            return Function.Call<float>((Hash)0x65499865FCA6E5EC, door);
+            return Function.Call<float>(Hash.DOOR_SYSTEM_GET_OPEN_RATIO, door);
         }
 
         public static float GetDoorOpenRatio(GarageDoor garageDoor)
         {
-            return Function.Call<float>((Hash)0x65499865FCA6E5EC, garageDoor);
+            return Function.Call<float>(Hash.DOOR_SYSTEM_GET_OPEN_RATIO, garageDoor);
         }
 
         public static DoorState GetDoorState(GarageDoor garageDoor)
         {
-            return Function.Call<DoorState>((Hash)0x160AA1B32F6139B8, garageDoor);
+            return Function.Call<DoorState>(Hash.DOOR_SYSTEM_GET_DOOR_STATE, garageDoor);
         }
 
         public static DoorState GetDoorState(Hash door)
         {
-            return Function.Call<DoorState>((Hash)0x160AA1B32F6139B8, door);
+            return Function.Call<DoorState>(Hash.DOOR_SYSTEM_GET_DOOR_STATE, door);
         }
 
         public static DoorState GetDoorPendingState(GarageDoor garageDoor)
         {
-            return Function.Call<DoorState>((Hash)0x4BC2854478F3A749, garageDoor);
+            return Function.Call<DoorState>(Hash.DOOR_SYSTEM_GET_DOOR_PENDING_STATE, garageDoor);
         }
 
         public static DoorState GetDoorPendingState(Hash door)
         {
-            return Function.Call<DoorState>((Hash)0x4BC2854478F3A749, door);
+            return Function.Call<DoorState>(Hash.DOOR_SYSTEM_GET_DOOR_PENDING_STATE, door);
         }
 
         public static void SetDoorState(GarageDoor garageDoor, DoorState doorState, bool requestDoor = false, bool forceUpdate = false)
         {
-            Function.Call((Hash)0x6BAB9442830C7F53, garageDoor, doorState, requestDoor, forceUpdate);
+            Function.Call(Hash.DOOR_SYSTEM_SET_DOOR_STATE, garageDoor, doorState, requestDoor, forceUpdate);
         }
 
         public static void SetDoorState(Hash door, DoorState doorState, bool requestDoor = false, bool forceUpdate = false)
         {
-            Function.Call((Hash)0x6BAB9442830C7F53, door, doorState, requestDoor, forceUpdate);
+            Function.Call(Hash.DOOR_SYSTEM_SET_DOOR_STATE, door, doorState, requestDoor, forceUpdate);
         }
 
         public static unsafe Hash FindDoor(Vector3 position, Hash model)
         {
             int ret;
 
-            Function.Call<bool>((Hash)0x589F80B325CC82C5, position.X, position.Y, position.Z, model, &ret);
+            Function.Call<bool>(Hash.DOOR_SYSTEM_FIND_EXISTING_DOOR, position.X, position.Y, position.Z, model, &ret);
 
             return (Hash)ret;
         }

--- a/Replica/WeaponReplica.cs
+++ b/Replica/WeaponReplica.cs
@@ -10,18 +10,18 @@ namespace FusionLibrary
         {
             WeaponHash = weapon.Hash;
             Ammo = weapon.Ammo;
-            IsEquiped = ped.Weapons.Current == weapon;
+            IsEquipped = ped.Weapons.Current == weapon;
             IsAmmoLoaded = weapon.AmmoInClip > 0;
         }
 
         public WeaponHash WeaponHash { get; }
         public int Ammo { get; }
-        public bool IsEquiped { get; }
+        public bool IsEquipped { get; }
         public bool IsAmmoLoaded { get; }
 
         public void Give(Ped ped)
         {
-            ped.Weapons.Give(WeaponHash, Ammo, IsEquiped, IsAmmoLoaded);
+            ped.Weapons.Give(WeaponHash, Ammo, IsEquipped, IsAmmoLoaded);
         }
     }
 }


### PR DESCRIPTION
Since SHVDN 3.6.0 all natives now have proper names, so this updates all leftover manual hashes to proper native names.