### PR TITLE
Add IsOutInTheOpen

### DIFF
--- a/Extensions/EntityExtensions.cs
+++ b/Extensions/EntityExtensions.cs
@@ -230,6 +230,23 @@ namespace FusionLibrary.Extensions
         }
 
         /// <summary>
+        /// Checks to see if the given <paramref name="entity"/> is currently out in the open.
+        /// </summary>
+        /// <param name="entity">Instance of an <see cref="Entity"/>.</param>
+        /// <returns><see langword="true"/> if <paramref name="entity"/> is not obscured overhead; otherwise <see langword="false"/>.</returns>
+        public static bool IsOutInTheOpen(this Entity entity)
+        {
+            if (entity.Position.Z < World.GetGroundHeight(new Vector2(entity.Position.X, entity.Position.Y)) - 5)
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        /// <summary>
         /// Checks if <paramref name="taskType"/> is running for <paramref name="ped"/>.
         /// </summary>
         /// <param name="ped">Instance of a <see cref="Ped"/>.</param>


### PR DESCRIPTION
Adds a function that checks to see if a given entity is out in the open, i.e. not obscured by anything overhead. If the given entity is either underground (for example, in a metro station) or has some sort of structure overhead (such as in a parking garage), this will return false. Otherwise, it returns true. Useful for making sure peds are above ground, and if vehicles are in open areas.