### PR TITLE
Adjust Ground-related Functions

### DIFF
--- a/Extensions/EntityExtensions.cs
+++ b/Extensions/EntityExtensions.cs
@@ -230,6 +230,24 @@ namespace FusionLibrary.Extensions
         }
 
         /// <summary>
+        /// Checks to see if the given <paramref name="entity"/> is currently out in the open.
+        /// </summary>
+        /// <param name="entity">Instance of an <see cref="Entity"/>.</param>
+        /// <returns><see langword="true"/> if <paramref name="entity"/> is not obscured overhead; otherwise <see langword="false"/>.</returns>
+        public static bool IsOutInTheOpen(this Entity entity)
+        {
+            float height = entity.Position.Z - FusionUtils.GetPositionOnGround(entity.Position, 0).Z;
+            if (entity.Position.Z + height < World.GetGroundHeight(new Vector2(entity.Position.X, entity.Position.Y)))
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        /// <summary>
         /// Checks if <paramref name="taskType"/> is running for <paramref name="ped"/>.
         /// </summary>
         /// <param name="ped">Instance of a <see cref="Ped"/>.</param>

--- a/FusionUtils.cs
+++ b/FusionUtils.cs
@@ -633,7 +633,6 @@ namespace FusionLibrary
         {
             float result = -1;
 
-            position.Z += 2.5f;
             unsafe
             {
                 Function.Call(Hash.GET_GROUND_Z_FOR_3D_COORD, position.X, position.Y, position.Z, &result, false);
@@ -706,7 +705,8 @@ namespace FusionLibrary
         /// <returns><see langword="true"/> wheel is on rail tracks; otherwise <see langword="false"/>.</returns>
         internal static bool IsWheelOnTracks(Vector3 pos, Vehicle vehicle)
         {
-            RaycastResult ret = World.Raycast(pos, pos.GetSingleOffset(Coordinate.Z, -1), IntersectFlags.Map, vehicle);
+            float diff = GetPositionOnGround(pos, 0).Z - pos.Z;
+            RaycastResult ret = World.Raycast(pos, pos.GetSingleOffset(Coordinate.Z, diff), IntersectFlags.Map, vehicle);
 
             // Tracks materials
             List<MaterialHash> allowedSurfaces = new List<MaterialHash>


### PR DESCRIPTION
Removes hardcoded offset in GetPositionOnGround, replaces hardcoded raycast in IsWheelOnTracks with one that accounts for variability in wheel height, and adds a function called IsOutInTheOpen that checks to see if a given entity is out in the open, i.e. not obscured by anything overhead. If the given entity is either underground (for example, in a metro station) or has some sort of structure overhead (such as in a parking garage), this will return false. Otherwise, it returns true. Useful for making sure peds are above ground, and if vehicles are in open areas.