### PR TITLE
Correct RR function, bump version

### DIFF
--- a/FusionLibrary.nuspec
+++ b/FusionLibrary.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>FusionLibrary.SHVDN3</id>
-    <version>1.7.2</version>
+    <version>1.7.3</version>
     <authors>MrFusion92</authors>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">MIT</license>

--- a/FusionUtils.cs
+++ b/FusionUtils.cs
@@ -707,7 +707,7 @@ namespace FusionLibrary
         /// <returns><see langword="true"/> wheel is on rail tracks; otherwise <see langword="false"/>.</returns>
         internal static bool IsWheelOnTracks(Vector3 pos, Vehicle vehicle)
         {
-            float diff = GetPositionOnGround(pos, 0).Z - pos.Z;
+            float diff = GetPositionOnGround(pos, -0.01f).Z - pos.Z;
             RaycastResult ret = World.Raycast(pos, pos.GetSingleOffset(Coordinate.Z, diff), IntersectFlags.Map, vehicle);
 
             // Tracks materials

--- a/Prop/AnimatePropsHandler.cs
+++ b/Prop/AnimatePropsHandler.cs
@@ -128,7 +128,7 @@ namespace FusionLibrary
         /// <summary>
         /// Gets or sets the Alpha level of the <see cref="Props"/>.
         /// </summary>
-        public AlphaLevel Alpha 
+        public AlphaLevel Alpha
         {
             get => Props[0].Alpha;
 


### PR DESCRIPTION
Under several circumstances, updated IsWheelOnTracks code that accounted for wheel height above ground surface was returning None for ground surface material hash. This update adds a 0.01 vertical offset to make sure the raycast successfully detects the ground surface material hash. Also bumps FusionLibrary version to 1.7.3.