### PR TITLE
Don't let SHVDN crash for using absent native in b1737 or earlier

### DIFF
--- a/Other/VehicleModelInfo.cs
+++ b/Other/VehicleModelInfo.cs
@@ -22,7 +22,7 @@ namespace FusionLibrary
             Name = Function.Call<string>(Hash.GET_DISPLAY_NAME_FROM_VEHICLE_MODEL, hash);
             DisplayName = Function.Call<string>(Hash.GET_FILENAME_FOR_AUDIO_CONVERSATION, Name);
 
-            MakeName = Function.Call<string>(Hash.GET_MAKE_NAME_FROM_VEHICLE_MODEL, hash);
+            MakeName = Vehicle.GetModelMakeName(Model);
             DisplayMakeName = Function.Call<string>(Hash.GET_FILENAME_FOR_AUDIO_CONVERSATION, MakeName);
 
             VehicleClass = Function.Call<VehicleClass>(Hash.GET_VEHICLE_CLASS_FROM_NAME, hash);


### PR DESCRIPTION
Hi, I'm the current project lead of SHVDN (crosire practically [retired his position](https://github.com/scripthookvdotnet/scripthookvdotnet/issues/1222)). It would be great if you let me introduce a compatibility patch for older game versions.

I know BTTFV won't work in the game version older than b1290 due to absence of game code for vehicle special flight in the exe, but still "Can't find native" error on the SHVDN launch disturbed me. `Vehicle.GetModelMakeName(Model)` supports all the game version since `CVehicleModelInfo` has a member for a make name string in all game versions, and now SHVDN won't crash upon this script loading (I know FusionLibrary is not intended to use without BTTFV, but still annoyed me). Maybe I'm missing this script calling some natives only available since b1365 or some later game version though...