### PR TITLE
ModelSwap, AnimateProp fixes

### DIFF
--- a/Prop/AnimateProp.cs
+++ b/Prop/AnimateProp.cs
@@ -34,6 +34,11 @@ namespace FusionLibrary
         public Entity Entity { get; protected set; }
 
         /// <summary>
+        /// Whether this <see cref="AnimateProp"/> should follow the visibility of its associated <see cref="GTA.Entity"/>.
+        /// </summary>
+        public bool InheritsEntityVisibility { get; set; } = true;
+
+        /// <summary>
         /// Whether any animation of this <see cref="AnimateProp"/> is playing.
         /// </summary>
         public bool IsPlaying { get; private set; }
@@ -173,7 +178,7 @@ namespace FusionLibrary
         /// <param name="entityBone"><see cref="EntityBone"/> of <paramref name="entity"/>.</param>
         /// <param name="offset">Offset relative to <paramref name="entityBone"/>. Default <see cref="Vector3.Zero"/>.</param>
         /// <param name="rotation">Rotation relative to <paramref name="entityBone"/>. Default <see cref="Vector3.Zero"/>.</param>
-        /// <param name="keepCollision">Whether keep collision when attached to <paramref name="entity"/>.</param>
+        /// <param name="keepCollision">Whether to keep collision when attached to <paramref name="entity"/>.</param>
         public AnimateProp(CustomModel model, Entity entity, EntityBone entityBone, Vector3 offset = default, Vector3 rotation = default, bool keepCollision = true)
         {
             Model = model;
@@ -229,9 +234,6 @@ namespace FusionLibrary
             {
                 if (Prop.NotNullAndExists() && Prop.IsVisible != _visible)
                 {
-                    if (Entity.NotNullAndExists() && !Entity.IsVisible)
-                        return _visible;
-
                     _visible = Prop.IsVisible;
                 }
 
@@ -621,12 +623,12 @@ namespace FusionLibrary
                 Prop.SetAlpha(Alpha);
             }
 
-            if (!Entity.IsVisible && Prop.IsVisible)
+            if (!Entity.IsVisible && Prop.IsVisible && InheritsEntityVisibility)
             {
                 Prop.IsVisible = false;
             }
 
-            if (Entity.IsVisible && !Prop.IsVisible && _visible)
+            if (Entity.IsVisible && !Prop.IsVisible && _visible && InheritsEntityVisibility)
             {
                 Prop.IsVisible = true;
             }

--- a/Traffic/ModelSwap.cs
+++ b/Traffic/ModelSwap.cs
@@ -77,47 +77,31 @@ namespace FusionLibrary
             foreach (string model in ModelsToSwap)
                 swapModels.Add(new CustomModel(model));
 
-            endTime = EndProductionDate.AddYears(5);
-            endSpan = (float)(endTime - EndProductionDate).TotalSeconds;
+            endTime = EndProductionDate.AddYears(10);
+            endSpan = (float)(endTime - EndProductionDate).TotalDays;
 
             modelInit = true;
         }
-
-        //public ModelSwap()
-        //{
-
-        //}
-
-        //internal ModelSwap(VehicleModelInfo vehicleModelInfo, int year)
-        //{
-        //    Enabled = false;
-
-        //    Model = vehicleModelInfo.Name;
-        //    VehicleType = vehicleModelInfo.VehicleType;
-        //    VehicleClass = vehicleModelInfo.VehicleClass;
-
-        //    DateBased = true;
-        //    StartProductionDate = new DateTime(year, 1, 1, 0, 0, 0);
-        //    EndProductionDate = new DateTime(year + 5, 1, 1, 0, 0, 0);
-
-        //    MaxSpawned = FusionUtils.Random.Next(1, 3);
-        //}
 
         internal void Process()
         {
             if (!modelInit)
                 Init();
 
-            if (!Enabled || Game.GameTime < gameTime || (DateBased && !FusionUtils.CurrentTime.Between(StartProductionDate, endTime)) || FusionUtils.AllVehicles.Count(x => x.Model == baseModel) >= MaxInWorld)
+            if (!Enabled || Game.GameTime < gameTime || (DateBased && FusionUtils.CurrentTime < StartProductionDate.AddMonths(4)) || FusionUtils.AllVehicles.Count(x => x.Model == baseModel) >= MaxInWorld)
                 return;
 
             float chanceMulti = 1f;
 
             if (FusionUtils.CurrentTime.Between(EndProductionDate, endTime))
             {
-                chanceMulti = (float)(endTime - FusionUtils.CurrentTime).TotalSeconds;
-                chanceMulti = chanceMulti.Remap(0, endSpan, 0, 1);
+                chanceMulti = (float)(endTime - FusionUtils.CurrentTime).TotalDays;
+                chanceMulti = chanceMulti.Remap(0, endSpan, 1, 0);
                 chanceMulti = Math.Max(chanceMulti, 0.02f);
+            }
+            else if (FusionUtils.CurrentTime > endTime)
+            {
+                chanceMulti = 0.02f;
             }
 
             float chance = (float)Math.Round(FusionUtils.Random.NextDouble(), 2);

--- a/Traffic/ModelSwap.cs
+++ b/Traffic/ModelSwap.cs
@@ -91,15 +91,15 @@ namespace FusionLibrary
             if (!Enabled || Game.GameTime < gameTime || (DateBased && FusionUtils.CurrentTime < StartProductionDate.AddMonths(4)) || FusionUtils.AllVehicles.Count(x => x.Model == baseModel) >= MaxInWorld)
                 return;
 
-            float chanceMulti = 1f;
+            float chanceMulti = 0.5f;
 
-            if (FusionUtils.CurrentTime.Between(EndProductionDate, endTime))
+            if (DateBased && FusionUtils.CurrentTime.Between(EndProductionDate, endTime))
             {
                 chanceMulti = (float)(endTime - FusionUtils.CurrentTime).TotalDays;
                 chanceMulti = chanceMulti.Remap(0, endSpan, 1, 0);
                 chanceMulti = Math.Max(chanceMulti, 0.02f);
             }
-            else if (FusionUtils.CurrentTime > endTime)
+            else if (DateBased && FusionUtils.CurrentTime > endTime)
             {
                 chanceMulti = 0.02f;
             }

--- a/Traffic/ModelSwap.cs
+++ b/Traffic/ModelSwap.cs
@@ -91,12 +91,12 @@ namespace FusionLibrary
             if (!Enabled || Game.GameTime < gameTime || (DateBased && FusionUtils.CurrentTime < StartProductionDate.AddMonths(4)) || FusionUtils.AllVehicles.Count(x => x.Model == baseModel) >= MaxInWorld)
                 return;
 
-            float chanceMulti = 0.5f;
+            float chanceMulti = 1f;
 
             if (DateBased && FusionUtils.CurrentTime.Between(EndProductionDate, endTime))
             {
                 chanceMulti = (float)(endTime - FusionUtils.CurrentTime).TotalDays;
-                chanceMulti = chanceMulti.Remap(0, endSpan, 1, 0);
+                chanceMulti = chanceMulti.Remap(0f, endSpan, 1f, 0f);
                 chanceMulti = Math.Max(chanceMulti, 0.02f);
             }
             else if (DateBased && FusionUtils.CurrentTime > endTime)


### PR DESCRIPTION
Fixed bug where DateBased math was being applied to all vehicles instead of just DateBased ones, fixed bug where the closer you were to the end of production the less likely you were to find a vehicle, made it so DateBased vehicles will not appear until 4 months after start of production to imitate the time it takes to get from a factory to a dealership, made it so the endTime for DateBased vehicles is 10 years rather than 5 years, made it so the chance of running into a DateBased vehicle 10 years after end of production is 0.02f rather than 0 as old cars are rare but not nonexistent, and changed the chanceMultiplier calculation for DateBased vehicles to use Days rather than Seconds as calculating Seconds for 10 years was causing stuttering in high-traffic high-speed environments.

EDIT: Also added a commit that fixes a visibility bug that crept into AnimateProp unnoticed.