### PR TITLE
Fix prop bug, bump version

### DIFF
--- a/FusionLibrary.csproj
+++ b/FusionLibrary.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProjectGuid>{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -13,33 +13,13 @@
     <FileAlignment>512</FileAlignment>
     <Deterministic>false</Deterministic>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DocumentationFile>bin\Debug\FusionLibrary.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DocumentationFile>bin\Release\FusionLibrary.xml</DocumentationFile>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>bin\x64\Debug\FusionLibrary.xml</DocumentationFile>
+    <Optimize>false</Optimize>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>7.3</LangVersion>

--- a/FusionLibrary.nuspec
+++ b/FusionLibrary.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>FusionLibrary.SHVDN3</id>
-    <version>1.7.4</version>
+    <version>1.7.5</version>
     <authors>MrFusion92</authors>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">MIT</license>

--- a/FusionLibrary.sln
+++ b/FusionLibrary.sln
@@ -7,18 +7,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FusionLibrary", "FusionLibr
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
-		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Debug|x64.ActiveCfg = Debug|x64
 		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Debug|x64.Build.0 = Debug|x64
-		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Release|x64.ActiveCfg = Release|x64
 		{F5AAD1BD-63CA-4A12-97A8-F0D876AB4462}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection

--- a/Prop/AnimateProp.cs
+++ b/Prop/AnimateProp.cs
@@ -604,7 +604,7 @@ namespace FusionLibrary
                 return;
             }
 
-            if (!Entity.NotNullAndExists() | !Prop.NotNullAndExists())
+            if (!Entity.NotNullAndExists() || !Prop.NotNullAndExists())
             {
                 Delete();
                 return;

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // È possibile specificare tutti i valori oppure impostare valori predefiniti per i numeri relativi alla revisione e alla build
 // usando l'asterisco '*' come illustrato di seguito:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.*")]
+[assembly: AssemblyVersion("1.7.*")]
 //[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
This PR fixes a conditional check in AnimateProp.cs to use a logical OR instead of a bitwise OR, updates AssemblyInfo.cs to build a DLL with the correct 1.7.x version numbering, updates several build files to correctly build targeting x64, and updates the nuspec version string to 1.7.5 to account for all of these changes.